### PR TITLE
Remove deprection warning.

### DIFF
--- a/build/js/tempusdominus-bootstrap.js
+++ b/build/js/tempusdominus-bootstrap.js
@@ -625,7 +625,7 @@ var DateTimePicker = function ($, moment) {
     _proto._areSameDates = function _areSameDates(a, b) {
       var format = this._format();
 
-      return a && b && (a.isSame(b) || moment(a.format(format)).isSame(b.format(format)));
+      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(b.format(format)));
     };
 
     _proto._notifyEvent = function _notifyEvent(e) {

--- a/build/js/tempusdominus-bootstrap.js
+++ b/build/js/tempusdominus-bootstrap.js
@@ -625,7 +625,7 @@ var DateTimePicker = function ($, moment) {
     _proto._areSameDates = function _areSameDates(a, b) {
       var format = this._format();
 
-      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(b.format(format)));
+      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(moment(b.format(format), format)));
     };
 
     _proto._notifyEvent = function _notifyEvent(e) {

--- a/src/docs/theme/js/tempusdominus-bootstrap.js
+++ b/src/docs/theme/js/tempusdominus-bootstrap.js
@@ -625,7 +625,7 @@ var DateTimePicker = function ($, moment) {
     _proto._areSameDates = function _areSameDates(a, b) {
       var format = this._format();
 
-      return a && b && (a.isSame(b) || moment(a.format(format)).isSame(b.format(format)));
+      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(b.format(format)));
     };
 
     _proto._notifyEvent = function _notifyEvent(e) {

--- a/src/docs/theme/js/tempusdominus-bootstrap.js
+++ b/src/docs/theme/js/tempusdominus-bootstrap.js
@@ -625,7 +625,7 @@ var DateTimePicker = function ($, moment) {
     _proto._areSameDates = function _areSameDates(a, b) {
       var format = this._format();
 
-      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(b.format(format)));
+      return a && b && (a.isSame(b) || moment(a.format(format), format).isSame(moment(b.format(format), format)));
     };
 
     _proto._notifyEvent = function _notifyEvent(e) {


### PR DESCRIPTION
Call moment constructor with a string that is not an ISO date triggers a deprecation warning.
I caused this by setting the date on a datepicker with a non-standard format ('hh:mm MM D, YYYY' in my case). In the console it shows:
> Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.

The one place I found that type of constructor, it was easily solved by passing the format as a second parameter to the constructor.